### PR TITLE
fix touchpad panning not preventing smart FPS from reducing the framerate

### DIFF
--- a/Rysy/Components/SmartFPSHandler.cs
+++ b/Rysy/Components/SmartFPSHandler.cs
@@ -28,6 +28,7 @@ public sealed class SmartFpsHandler : SceneComponent, ISignalListener<SettingsCh
 
         if (input.Mouse.PositionDelta == Point.Zero 
         && input.Mouse.ScrollDelta == 0 
+        && input.Mouse.TouchpadPan == Vector2.Zero
         && !input.Keyboard.AnyKeyHeld 
         && !input.Mouse.AnyClickedOrHeld
         && !ImGuiManager.WantCaptureMouse) {


### PR DESCRIPTION
previously, touchpad panning after the mouse has been idle for a second with smart FPS enabled would result in very choppy scrolling, since as far as the handler was concerned, the user was idle. now it checks for `input.Mouse.TouchpadPan`, resolving this issue