### PR TITLE
removed "fan" node path type

### DIFF
--- a/Rysy/Entities/Strawberry.cs
+++ b/Rysy/Entities/Strawberry.cs
@@ -17,8 +17,6 @@ public class Strawberry : SpriteEntity, IPlaceable {
 
     public bool Moon => Bool("moon");
 
-    public override IEnumerable<ISprite> GetNodePathSprites() => NodePathTypes.Fan(this);
-
     public override IEnumerable<ISprite> GetNodeSprites(int nodeIndex) {
         yield return GetSprite("collectables/strawberry/seed00") with {
             Pos = Nodes![nodeIndex]


### PR DESCRIPTION
strawberry seeds "flash" in their node order, so the placement should reflect this so the mapper can easily control the flashing order ingame