### PR TITLE
make celeste install picker select the game directory directly + add filepicker fallback

### DIFF
--- a/Rysy/Helpers/FileDialogHelper.cs
+++ b/Rysy/Helpers/FileDialogHelper.cs
@@ -26,9 +26,15 @@ public static class FileDialogHelper {
         return HandleResult(res, filterList, out chosenFile, "FileDialogHelper.TryOpen");
     }
 
-    private static bool HandleResult(DialogResult res, string filterList, [NotNullWhen(true)] out string? chosenFile, string logTag) {
+    public static bool TryOpenDir([NotNullWhen(true)] out string? chosenDir, string? defaultPath = null) {
+        var res = Dialog.FolderPicker((defaultPath ?? GetDefaultPath()).CorrectSlashes());
+
+        return HandleResult(res, extension: null, out chosenDir, "FileDialogHelper.TryOpenDir");
+    }
+
+    private static bool HandleResult(DialogResult res, string? extension, [NotNullWhen(true)] out string? chosen, string logTag) {
         if (res.IsOk) {
-            chosenFile = AddExtIfNeeded(filterList, res.Path);
+            chosen = AddExtIfNeeded(extension, res.Path);
             return true;
         }
 
@@ -36,15 +42,18 @@ public static class FileDialogHelper {
             Logger.Write(logTag, LogLevel.Error, $"Failed to pick path: {res.ErrorMessage}");
         }
 
-        chosenFile = null;
+        chosen = null;
         return false;
     }
 
-    private static string AddExtIfNeeded(string filterList, string chosenFile) {
-        var extString = $".{filterList}";
-        if (!chosenFile.EndsWith(extString, StringComparison.Ordinal))
-            chosenFile += extString;
+    private static string AddExtIfNeeded(string? extension, string chosen) {
+        if (extension is null)
+            return chosen;
 
-        return chosenFile;
+        var extString = $".{extension}";
+        if (!chosen.EndsWith(extString, StringComparison.Ordinal))
+            chosen += extString;
+
+        return chosen;
     }
 }

--- a/Rysy/Scenes/PickCelesteInstallScene.cs
+++ b/Rysy/Scenes/PickCelesteInstallScene.cs
@@ -1,5 +1,5 @@
-﻿using Rysy.Extensions;
 using Rysy.Graphics;
+using Rysy.Helpers;
 
 namespace Rysy.Scenes;
 
@@ -11,17 +11,18 @@ public class PickCelesteInstallScene : Scene {
 
     protected internal override void OnFileDrop(string filePath) {
         base.OnFileDrop(filePath);
+        StoreCelestePath(filePath); // if the dropped file is not a directory, this is a no-op
+    }
 
-        if (Path.GetFileName(filePath) is "Celeste.exe" or "Celeste.dll") {
-            var dir = Path.GetDirectoryName(filePath) ?? "";
-            // If the user provided the Celeste.exe in the '/orig' directory, silently fix the path to use the main dir instead.
-            if (dir.EndsWith("/orig", StringComparison.Ordinal) || dir.EndsWith("\\orig", StringComparison.Ordinal)) {
-                var mainDir = dir[..^"/orig".Length];
-                if (File.Exists(Path.Combine(mainDir, "Celeste.exe"))) {
-                    dir = mainDir;
-                }
+    private void StoreCelestePath(string dirPath) {
+        if (Directory.Exists(dirPath)) {
+            string fullPath;
+            try {
+                fullPath = Path.GetFullPath(dirPath);
+            } catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException) {
+                return;
             }
-            Profile.Instance.CelesteDirectory = dir;
+            Profile.Instance.CelesteDirectory = fullPath;
             Profile.Instance.Save();
 
             RysyEngine.Scene = _nextScene;
@@ -41,9 +42,19 @@ public class PickCelesteInstallScene : Scene {
         var windowSize = RysyState.Window.ClientBounds.Size();
         var height = 4 * 6;
         var center = windowSize.Y / 2;
-        PicoFont.Print("Please drop the", new Rectangle(0, center - 32, windowSize.X, height), Color.White, scale: 4f);
-        PicoFont.Print("Celeste.exe/Celeste.dll", new Rectangle(0, center, windowSize.X, height), Color.LightSkyBlue, scale: 4f);
-        PicoFont.Print("file onto this window", new Rectangle(0, center + 32, windowSize.X, height), Color.White, scale: 4f);
+        PicoFont.Print("Please drop the", new Rectangle(0, center - 48, windowSize.X, height), Color.White, scale: 4f);
+        PicoFont.Print("Celeste game directory", new Rectangle(0, center - 16, windowSize.X, height), Color.LightSkyBlue, scale: 4f);
+        PicoFont.Print("game directory", new Rectangle(PicoFont.W * 2 * "Celeste ".Length, center - 16, windowSize.X, height), Color.White, scale: 4f);
+        PicoFont.Print("onto this window", new Rectangle(0, center + 16, windowSize.X, height), Color.White, scale: 4f);
+        PicoFont.Print("(or click to browse)", new Rectangle(0, center + 48, windowSize.X, height), Color.White, scale: 4f);
         Gfx.EndBatch();
+    }
+
+    public override void Update() {
+        if (Input.Global?.Mouse.Clicked(0) ?? false) {
+            if (FileDialogHelper.TryOpenDir(out string? dirPath)) {
+                StoreCelestePath(dirPath);
+            }
+        }
     }
 }


### PR DESCRIPTION
right now, the celeste install picker asks for `Celeste.exe` / `Celeste.dll`, which is a bit misleading, as it needs the entire game install but the request makes it seem like a standalone dll is sufficient. i've ran into this problem directly, i noticed it asks for the celeste dll and thought giving it a standalone dll, which i conveniently had a copy of in my documents directory, was enough

additionally, right now, the only provided option is drag-and-drop, which on some systems is either limited / inconvenient to use or outright unavailable. it's always possible to install a dedicated drag-and-drop tool like ripdrag, but nevertheless there should exist a fallback option

this pr changes `PickCelesteInstallScene` to ask the user for the install directory directly rather than inferring it from the dll path, as well as adding the option to click on the window to select a celeste install via a filepicker